### PR TITLE
Patched 2 networking and dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,6 +3002,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "ejs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.0.1.tgz",
+      "integrity": "sha512-cuIMtJwxvzumSAkqaaoGY/L6Fc/t6YvoP9/VIaK0V/CyqKLEQ8sqODmYfy/cjXEdZ9+OOL8TecbJu+1RsofGDw=="
+    },
     "electron-to-chromium": {
       "version": "1.3.322",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
@@ -3686,7 +3691,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3707,12 +3713,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3727,17 +3735,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3854,7 +3865,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3866,6 +3878,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3880,6 +3893,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3887,12 +3901,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3911,6 +3927,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3991,7 +4008,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4003,6 +4021,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4088,7 +4107,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4124,6 +4144,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4143,6 +4164,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4186,12 +4208,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-polyfill": "^6.26.0",
     "bcrypt": "^4.0.0",
     "cors": "^2.8.5",
+    "ejs": "latest",
     "express": "^4.16.4",
     "express-flash": "0.0.2",
     "express-session": "^1.17.0",

--- a/src/client/scenes/NetworkScene.ts
+++ b/src/client/scenes/NetworkScene.ts
@@ -8,7 +8,7 @@ export class NetworkScene extends Phaser.Scene
     public constructor(key: string | Phaser.Types.Scenes.SettingsConfig)
     {
         super(key)
-        this.socket = socketio(`http://localhost:${config.default.server_port}/client`)
+        this.socket = socketio(`http://${config.default.server_ip}:${config.default.server_port}/client`)
     } 
 
     public getSocket() : SocketIOClient.Socket
@@ -18,7 +18,7 @@ export class NetworkScene extends Phaser.Scene
 
     public initSocket() : void
     {
-        this.socket = socketio(`http://localhost:${config.default.server_port}/client`)
+        this.socket = socketio(`http://${config.default.server_ip}:${config.default.server_port}/client`)
     }
 
 }

--- a/src/client/scenes/SpectatorScene.ts
+++ b/src/client/scenes/SpectatorScene.ts
@@ -28,7 +28,7 @@ export class SpectatorScene extends Phaser.Scene {
         let playerUsername: string = document.getElementById('username').innerHTML
         this.cameras.add(0, 0, window.innerWidth, window.innerHeight).setName('staticCamera')
 
-        this.socket = socketio(`http://localhost:${config.default.server_port}/client`)
+        this.socket = socketio(`http://${config.default.server_ip}:${config.default.server_port}/client`)
         let step = GameMap.settings.gridStep
 
         for (let x: number = -this.gameMapBounds[0] / 2 + step / 2; x < this.gameMapBounds[0] / 2 + step / 2; x += step) {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,3 +1,4 @@
 export default {
-    server_port: 3000
+    server_port: 3000,
+    server_ip: "192.168.43.107"
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -184,7 +184,7 @@ io.of('/client').on("connection", (socket: Socket) => {
     })
 })
 
-http.listen(conf.server_port, () => { 
+http.listen(conf.server_port, "0.0.0.0", () => { 
     console.log(`server started on port ${conf.server_port}`)
     spawnObjects()
 })


### PR DESCRIPTION
When the game was tried in production mode, it didn't work because of two things:

1.  The dependency `ejs` was missing
2. The client side of the game had `localhost` hardcoded and this won't work when the client isn't the server

To resolve this issue, an ip address of the server the game was tested on was added to the config file. This is a temporary fix and a command should be used to fetch the ip address of the server, so as to avoid a modification of the file when the game is run on a different machine.